### PR TITLE
Bump up kotlin and compose compiler version for Compose 1.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.2.0'
+        kotlinCompilerExtensionVersion '1.4.4'
     }
     packagingOptions {
         resources {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ gradle-version = "7.4.2"
 # https://github.com/JLLeitschuh/ktlint-gradle/releases
 ktlint = "11.3.1"
 
-kotlin = "1.7.0"
+kotlin = "1.8.10"
 
 [libraries]
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }


### PR DESCRIPTION
Key changes
- Updated Kotlin version to `1.8.10` which is compatible with Jetpack Compose 1.4.
- Updated Compose Compier version to `1.4.4` which is compatible with Kotlin `1.8.10`.


Closes #13 