### PR TITLE
Get compose compiler version from the toml file.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.2.0'
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
     packagingOptions {
         resources {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,8 @@ gradle-version = "7.4.2"
 # https://github.com/JLLeitschuh/ktlint-gradle/releases
 ktlint = "11.3.1"
 
-kotlin = "1.7.0"
+kotlin = "1.8.10"
+compose-compiler = "1.4.4"
 
 [libraries]
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }


### PR DESCRIPTION
You don't need `libs.version.xx.asProvider().get()` to get the version number, use `libs.versions.xx.get()` to get the version number.

Closes #2 